### PR TITLE
Add naive support for Blackwell sm100/sm103

### DIFF
--- a/humming/tune/__init__.py
+++ b/humming/tune/__init__.py
@@ -14,6 +14,7 @@ from humming.tune.sm8x import (
 from humming.tune.sm75 import Sm75Heuristics
 from humming.tune.sm90 import Sm90Heuristics
 from humming.tune.sm90_h20 import Sm90H20Heuristics
+from humming.tune.sm100 import Sm100Heuristics
 
 if TYPE_CHECKING:
     from humming.layer import HummingLayerMeta
@@ -25,6 +26,8 @@ heuristics_map: dict[int, type[DeviceHeuristics]] = {
     87: Sm87Heuristics,
     89: Sm89Heuristics,
     90: Sm90Heuristics,
+    100: Sm100Heuristics,
+    103: Sm100Heuristics,
 }
 
 

--- a/humming/tune/sm100.py
+++ b/humming/tune/sm100.py
@@ -1,0 +1,9 @@
+from humming import dtypes
+from humming.tune.sm8x import Sm80Heuristics
+
+
+# TODO (mgoin): add proper heuristics
+class Sm100Heuristics(Sm80Heuristics):
+    max_smem_size: int = 227 * 1024
+    sm_version: int = 100
+    b8_allowed_dtypes: list[dtypes.DataType] = [dtypes.int8, dtypes.float8e4m3, dtypes.float8e5m2]

--- a/humming/utils/device.py
+++ b/humming/utils/device.py
@@ -45,7 +45,7 @@ def estimate_tensorcore_max_tops(gpu_index=0):
         max_clock_mhz = pynvml.nvmlDeviceGetMaxClockInfo(handle, pynvml.NVML_CLOCK_SM)
         sm_count = torch.cuda.get_device_properties(gpu_index).multi_processor_count
 
-        ops_map = {75: 1024, 80: 2048, 86: 1024, 87: 2048, 89: 1024, 90: 4096}
+        ops_map = {75: 1024, 80: 2048, 86: 1024, 87: 2048, 89: 1024, 90: 4096, 100: 8192, 103: 8192}
         ops_per_clock = ops_map[sm_version]
 
         # 1. This function returns the dense FP16 Tensor Core performance (FP16 accumulator).


### PR DESCRIPTION
Dispatches sm100 (B100/B200) and sm103 (B300) to a provisional Sm100Heuristics class that reuses the Sm89 plain-mma path with the Blackwell smem capacity. Also extends the tensor-core ops_map so estimate_compute_bound_threshold doesn't KeyError on Blackwell. Tuned configs (WGMMA/TMA/cluster/tcgen05) are still TODO.