### PR TITLE
fix: propagate CUDA device to ThreadPoolExecutor workers in prepare_k…

### DIFF
--- a/humming/kernel/humming.py
+++ b/humming/kernel/humming.py
@@ -385,16 +385,14 @@ class HummingKernel(KernelRuntime, LayerConfig, ComputeConfig, TuningConfig):
             # Capture the current CUDA device so worker threads use the correct GPU;
             # CUDA device is thread-local and new threads default to GPU 0.
             _current_device = torch.cuda.current_device()
-
-            def _prepare_kernel_with_device(data):
-                torch.cuda.set_device(_current_device)
-                return prepare_kernel(data)
-
-            executor = ThreadPoolExecutor(max_workers=16)
-            for config, kernel, num_sms in executor.map(_prepare_kernel_with_device, tuning_config_obj):
-                kernel.load_cubin()
-                res += [config[0], config[1], kernel.kernel_id, num_sms]
-            executor.shutdown(wait=False)
+            with ThreadPoolExecutor(
+                max_workers=16,
+                initializer=torch.cuda.set_device,
+                initargs=(_current_device,),
+            ) as executor:
+                for config, kernel, num_sms in executor.map(prepare_kernel, tuning_config_obj):
+                    kernel.load_cubin()
+                    res += [config[0], config[1], kernel.kernel_id, num_sms]
         else:
             for config in tuning_config_obj:
                 kernel_config, kernel, num_sms = prepare_kernel(config)

--- a/humming/kernel/humming.py
+++ b/humming/kernel/humming.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import ClassVar
 
 import jinja2
+import torch
 
 import humming.utils.jit as jit_utils
 from humming import dtypes
@@ -381,8 +382,16 @@ class HummingKernel(KernelRuntime, LayerConfig, ComputeConfig, TuningConfig):
             # Parallelize kernel compilation using multiple threads,
             # but ensure kernel loading occurs in the main thread to prevent CUDA context issues.
             # (KernelRuntime would skip loading when running in child thread).
+            # Capture the current CUDA device so worker threads use the correct GPU;
+            # CUDA device is thread-local and new threads default to GPU 0.
+            _current_device = torch.cuda.current_device()
+
+            def _prepare_kernel_with_device(data):
+                torch.cuda.set_device(_current_device)
+                return prepare_kernel(data)
+
             executor = ThreadPoolExecutor(max_workers=16)
-            for config, kernel, num_sms in executor.map(prepare_kernel, tuning_config_obj):
+            for config, kernel, num_sms in executor.map(_prepare_kernel_with_device, tuning_config_obj):
                 kernel.load_cubin()
                 res += [config[0], config[1], kernel.kernel_id, num_sms]
             executor.shutdown(wait=False)


### PR DESCRIPTION
---
Description:

Root Cause

HummingKernel.prepare_kernels uses a ThreadPoolExecutor(max_workers=16) to parallelize kernel compilation. Each worker thread calls HummingKernel(**config), which triggers:

KernelRuntime.__post_init__
→ init_sm_version() # torch.cuda.get_device_properties()
→ init_kernel() → prepare()
→ _ensure_cuda_context() # torch.cuda.set_device(torch.cuda.current_device())

CUDA device assignment is thread-local in the CUDA driver API. ThreadPoolExecutor worker threads do not inherit the spawning thread's current device — they start with current_device() = 0. As a result, on any
 multi-GPU setup (TP ≥ 2), every worker process initializes a spurious CUDA primary context on GPU 0 inside these pool threads.

Impact

On an 8-GPU setup (TP=8):
- Worker processes for ranks 1–7 each create an extra CUDA context on GPU 0 (~284 MiB each)
- Total: 7 × 284 MiB ≈ 1.96 GiB of wasted memory on GPU 0
- This directly reduces KV cache capacity on GPU 0, making it the bottleneck for long-context inference
- The bug affects all GPU architectures (A100, H100, L20, etc.) — not environment-specific

Fix

Capture the correct device in the main thread before submitting to the pool, and set it at the start of each worker:

_current_device = torch.cuda.current_device()

def _prepare_kernel_with_device(data):
  torch.cuda.set_device(_current_device)
  return prepare_kernel(data)

executor = ThreadPoolExecutor(max_workers=16)
for config, kernel, num_sms in executor.map(_prepare_kernel_with_device, tuning_config_obj):
  ... 
 
Note: the existing comment already acknowledged CUDA context issues with threading (for load_cubin), but the device propagation for compilation workers was missed. 

Before fix: ranks 1–N each show ~284 MiB allocated on GPU 0 (spurious context). 
After fix: only rank 0 shows allocation on GPU 0. 

Alternatively, compare non_torch_increase from vLLM's memory profiler on GPU 0 vs other GPUs — they should now be equal.
 
--- 

▎ This PR was developed with AI assistance (Claude).
