### PR TITLE
fix bench_humming pass expert_max_tokens to moe tensor generator

### DIFF
--- a/benchmarks/bench_humming.py
+++ b/benchmarks/bench_humming.py
@@ -109,6 +109,7 @@ def bench_humming(
                 gemm_type=gemm_type,
                 balanced=balanced,
                 block_size_config=block_size_config,
+                expert_max_tokens=expert_max_tokens,
             )
             _, expert_layout, sorted_ids, expert_ids, num_tokens_padded = moe_tensors
 


### PR DESCRIPTION
generate_random_moe_tensors asserts expert_max_tokens is not None for GemmType.GROUPED_MASKED, so propagate it from bench_humming.