### PR TITLE
Fix indexed activation scale offset

### DIFF
--- a/humming/include/humming/memory/g2s_loader/loader_as.cuh
+++ b/humming/include/humming/memory/g2s_loader/loader_as.cuh
@@ -116,7 +116,7 @@ public:
     if constexpr (!kIsIndexedGemm) {
       gmem_ptr = gmem_ptr_raw + ((row_offset * kProblemNumGroups) + col_offset);
     } else {
-      gmem_ptr = gmem_ptr_raw;
+      gmem_ptr = gmem_ptr_raw + col_offset;
 
       constexpr uint32_t kSmemStride = kNumGroups / (sizeof(LoadType) / 4);
       uint32_t smem_row = threadIdx.x / kSmemStride;

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -7,6 +7,7 @@ from humming.utils.test import (
     generate_random_inputs,
     generate_random_moe_tensors,
     generate_random_weight,
+    skip_if_unsupported,
 )
 from humming.utils.weight import (
     prepare_humming_weight,
@@ -74,6 +75,102 @@ def test_indexed_gemm(m, num_experts, top_k, block_shape_m):
 
     torch_dtype = dtypes.torch_dtype_map[c_dtype]
     outputs = torch.empty((m * top_k, 1024), dtype=torch_dtype, device=inputs.device)
+
+    outputs = ops.launch_kernel(
+        configs=[humming_kernel.kernel_id],
+        inputs=inputs,
+        weight=weight,
+        outputs=outputs,
+        input_scale=input_scale,
+        weight_scale=weight_scale,
+        expert_ids=expert_ids,
+        num_tokens_padded=num_tokens_padded,
+        sorted_ids=sorted_token_ids,
+        top_k=top_k,
+    )
+
+    outputs = outputs.view(-1, outputs.size(-1))
+    outputs_ref = torch.empty_like(outputs)
+
+    for expert_id in range(num_experts):
+        outputs_index = torch.where(topk_ids.view(-1) == expert_id)[0]
+        inputs_index = outputs_index // top_k
+        if inputs_index.size(0):
+            tmp = inputs_ref[inputs_index].matmul(weight_ref[expert_id].T)
+            outputs_ref[outputs_index] = tmp.to(torch_dtype)
+
+    torch.testing.assert_close(outputs, outputs_ref, rtol=0.05, atol=0.1)
+
+
+@pytest.mark.parametrize("input_scale_group_size", [128])
+def test_indexed_gemm_input_scale(input_scale_group_size):
+    a_dtype = "float8e4m3"
+    mma_type = "wgmma"
+    skip_if_unsupported(a_dtype=a_dtype, mma_type=mma_type)
+
+    c_dtype = dtypes.bfloat16
+    a_dtype = dtypes.DataType.from_str(a_dtype)
+    b_dtype = dtypes.uint4
+    bs_dtype = dtypes.bfloat16
+
+    m = 256
+    n = 1024
+    k = 1024
+    num_experts = 8
+    top_k = 1
+    block_shape_m = 48
+
+    moe_tensors = generate_random_moe_tensors(
+        m,
+        num_experts=num_experts,
+        top_k=top_k,
+        block_size_config=block_shape_m,
+    )
+    topk_ids, _, sorted_token_ids, expert_ids, num_tokens_padded = moe_tensors
+
+    random_weight_data = generate_random_weight(
+        n=n,
+        k=k,
+        group_size=0,
+        dtype=b_dtype,
+        scale_dtype=bs_dtype,
+        num_experts=num_experts,
+    )
+
+    _, weight_ref, weight, weight_scale, _, _ = random_weight_data
+    weight = prepare_humming_weight(weight, b_dtype, a_dtype, use_wgmma=mma_type == "wgmma")
+    weight_scale = prepare_humming_weight_scale(weight_scale, to_apply_on_c=True)
+
+    _, inputs_ref, inputs, input_scale = generate_random_inputs(
+        m=m,
+        k=k,
+        group_size=input_scale_group_size,
+        dtype=a_dtype,
+    )
+
+    humming_kernel = HummingKernel(
+        shape_n=n,
+        shape_k=k,
+        block_shape=(block_shape_m, a_dtype.num_bits * 16, 512 // a_dtype.num_bits),
+        warp_shape=(block_shape_m, a_dtype.num_bits * 4, 512 // a_dtype.num_bits),
+        a_dtype=a_dtype,
+        b_dtype=b_dtype,
+        c_dtype=c_dtype,
+        bs_dtype=bs_dtype,
+        num_experts=num_experts,
+        num_stages=3,
+        use_warp_spec=False,
+        use_tma=False,
+        use_cp_async=False,
+        has_bias=False,
+        input_scale_group_size=input_scale_group_size,
+        mma_type=mma_type,
+        use_stream_k=False,
+        gemm_type="indexed",
+    )
+
+    torch_dtype = dtypes.torch_dtype_map[c_dtype]
+    outputs = torch.empty((m * top_k, n), dtype=torch_dtype, device=inputs.device)
 
     outputs = ops.launch_kernel(
         configs=[humming_kernel.kernel_id],


### PR DESCRIPTION
## Summary

Fixes #19.

This changes the indexed GEMM activation-scale loader to apply the K-group `col_offset` when loading grouped input scales.

A targeted regression test is added in `tests/test_moe.py` following the existing MoE test style: parametrized input scale group size, repo helpers for random MoE/weight/input generation, `skip_if_unsupported`, `HummingKernel` launch, and `torch.testing.assert_close` against the quantized-input reference.

## Root cause

`G2SMemoryLoaderAS::seek()` already computes `col_offset` for grouped scales from `k_block_id`, but the indexed GEMM branch ignored it and used `gmem_ptr_raw` directly.

As a result, when `input_scale_group_size > 0`, every non-zero K block loaded the scale group for K=0. W4A16 and per-token activation scale are not affected because they do not need a K-group activation-scale offset.

## Reproduction data

Environment:

- Shape: `M=256, N=512, K=7168, E=8, top_k=1`
- Weight: `uint4`, `weight_scale_group_size=32`
- Output/reference dtype: `bfloat16`
- Metric: relative RMSE vs quantized-input reference

Before this fix:

| Case | rel_RMSE |
| --- | ---: |
| W4A16 bf16 | 0.002445 |
| W4A8 per-token input scale | 0.002450 |
| W4A8 grouped input scale, group_size=128 | 0.136284 |
| W4A8 grouped input scale, group_size=32 | 0.189305 |

After this fix:

| Case | rel_RMSE |
| --- | ---: |
| W4A8 per-token input scale | 0.00245 |
| W4A8 grouped input scale, group_size=128 | 0.00244 |
| W4A8 grouped input scale, group_size=32 | 0.00245 |

The grouped-input-scale cases now match the unaffected per-token/W4A16 accuracy level.

## Validation
- Re-ran the same repro after the fix and confirmed grouped input scale accuracy returned to baseline.
