### PR TITLE
fix humming tma smem alignment

### DIFF
--- a/humming/include/humming/utils/storage.cuh
+++ b/humming/include/humming/utils/storage.cuh
@@ -138,13 +138,13 @@ public:
 
   union alignas(128) {
     struct {
-      int4 a[kNumStages][kStageSizeA];
-      int4 b[kNumStages][kStageSizeB];
+      alignas(128) int4 a[kNumStages][kStageSizeA];
+      alignas(128) int4 b[kNumStages][kStageSizeB];
       IF_HAS_STAGE_INPUT_SCALE(int4 as[kNumStages][kStageSizeAS];)
-      IF_HAS_STAGE_WEIGHT_SCALE(int4 bs[kNumStages][kStageSizeBS];)
-      IF_HAS_ZERO_POINT(int4 bzp[kIsChannelWeightScale ? 1 : kNumStages][kIsChannelWeightScale ? kChannelSizeBZP : kStageSizeBZP];)
-      IF_HAS_CHANNEL_WEIGHT_SCALE(int4 bs_c[kChannelSizeBS];)
-      IF_HAS_BIAS(int4 bias[kBiasSize];)
+      IF_HAS_STAGE_WEIGHT_SCALE(alignas(128) int4 bs[kNumStages][kStageSizeBS];)
+      IF_HAS_ZERO_POINT(alignas(128) int4 bzp[kIsChannelWeightScale ? 1 : kNumStages][kIsChannelWeightScale ? kChannelSizeBZP : kStageSizeBZP];)
+      IF_HAS_CHANNEL_WEIGHT_SCALE(alignas(128) int4 bs_c[kChannelSizeBS];)
+      IF_HAS_BIAS(alignas(128) int4 bias[kBiasSize];)
       IF_HAS_CHANNEL_INPUT_SCALE(int4 as_c[kChannelSizeAS];)
     };
     int4 reduce[MAX(kWarpReduceSize, kBlockOutputSize)];

--- a/humming/include/humming/utils/storage.cuh
+++ b/humming/include/humming/utils/storage.cuh
@@ -122,6 +122,17 @@ public:
   static constexpr uint32_t kChannelSizeBZP = (kIsChannelWeightScale && kHasZeroPoint) ? kSmemStrideBZP : 0;
   static constexpr uint32_t kBiasSize = LayerConfig::kHasBias ? kSmemStrideBias : 0;
 
+  static constexpr uint32_t kTmaAlignmentInt4s = 128 / sizeof(int4);
+  static constexpr uint32_t align_tma_int4s(uint32_t size) {
+    return CEIL_DIV(size, kTmaAlignmentInt4s) * kTmaAlignmentInt4s;
+  }
+  // TMA needs every per-stage shared-memory tile base to be 128B aligned.
+  static constexpr uint32_t kStageSizeAStorage = align_tma_int4s(kStageSizeA);
+  static constexpr uint32_t kStageSizeBStorage = align_tma_int4s(kStageSizeB);
+  static constexpr uint32_t kStageSizeBSStorage = align_tma_int4s(kStageSizeBS);
+  static constexpr uint32_t kStageSizeBZPStorage = align_tma_int4s(
+      kIsChannelWeightScale ? kChannelSizeBZP : kStageSizeBZP);
+
   static constexpr uint32_t kStageBytesA = kStageSizeA * sizeof(int4);
   static constexpr uint32_t kStageBytesB = kStageSizeB * sizeof(int4);
   static constexpr uint32_t kStageBytesAS = kStageSizeAS * sizeof(int4);
@@ -138,11 +149,11 @@ public:
 
   union alignas(128) {
     struct {
-      alignas(128) int4 a[kNumStages][kStageSizeA];
-      alignas(128) int4 b[kNumStages][kStageSizeB];
+      alignas(128) int4 a[kNumStages][kStageSizeAStorage];
+      alignas(128) int4 b[kNumStages][kStageSizeBStorage];
       IF_HAS_STAGE_INPUT_SCALE(int4 as[kNumStages][kStageSizeAS];)
-      IF_HAS_STAGE_WEIGHT_SCALE(alignas(128) int4 bs[kNumStages][kStageSizeBS];)
-      IF_HAS_ZERO_POINT(alignas(128) int4 bzp[kIsChannelWeightScale ? 1 : kNumStages][kIsChannelWeightScale ? kChannelSizeBZP : kStageSizeBZP];)
+      IF_HAS_STAGE_WEIGHT_SCALE(alignas(128) int4 bs[kNumStages][kStageSizeBSStorage];)
+      IF_HAS_ZERO_POINT(alignas(128) int4 bzp[kIsChannelWeightScale ? 1 : kNumStages][kStageSizeBZPStorage];)
       IF_HAS_CHANNEL_WEIGHT_SCALE(alignas(128) int4 bs_c[kChannelSizeBS];)
       IF_HAS_BIAS(alignas(128) int4 bias[kBiasSize];)
       IF_HAS_CHANNEL_INPUT_SCALE(int4 as_c[kChannelSizeAS];)

--- a/humming/utils/smem.py
+++ b/humming/utils/smem.py
@@ -8,6 +8,12 @@ if TYPE_CHECKING:
     from humming.layer import HummingLayerMeta
 
 
+def _align_up(size: int, alignment: int = 128) -> int:
+    if size == 0:
+        return 0
+    return math.ceil(size / alignment) * alignment
+
+
 def estimate_smem_size(
     a_dtype: dtypes.DataType,
     b_dtype: dtypes.DataType,
@@ -54,8 +60,25 @@ def estimate_smem_size(
         else:
             as_channel_size = block_m * 4
 
-    stage_size = a_stage_size + b_stage_size + as_stage_size + bs_stage_size + bzp_stage_size
-    all_stages_size = stage_size * num_stages
+    offset = 0
+
+    def add_field(size: int, alignment: int = 1):
+        nonlocal offset
+        if size == 0:
+            return
+        offset = _align_up(offset, alignment)
+        offset += size
+
+    add_field(_align_up(a_stage_size) * num_stages, 128)
+    add_field(_align_up(b_stage_size) * num_stages, 128)
+    add_field(as_stage_size * num_stages)
+    add_field(_align_up(bs_stage_size) * num_stages, 128)
+    bzp_stages = 1 if weight_scale_group_size == 0 else num_stages
+    add_field(_align_up(bzp_stage_size or bzp_channel_size) * bzp_stages, 128)
+    add_field(bs_channel_size, 128)
+    add_field(bias_size, 128)
+    add_field(as_channel_size)
+
     moe_tensor_size = 0
     if gemm_type == GemmType.INDEXED:
         moe_tensor_size = block_m * 4 * 2
@@ -63,8 +86,7 @@ def estimate_smem_size(
         moe_tensor_size = num_experts * 4 * 2
     elif gemm_type == GemmType.GROUPED_MASKED:
         moe_tensor_size = num_experts * 4
-    size = all_stages_size + moe_tensor_size
-    size += as_channel_size + bs_channel_size + bzp_channel_size + bias_size
+    size = offset + moe_tensor_size
 
     return size
 


### PR DESCRIPTION
## Summary

This fixes a `CUDA_ERROR_MISALIGNED_ADDRESS` failure in Humming TMA paths by ensuring shared-memory regions used as TMA destinations are 128-byte aligned.

The failure was reproduced on DSV4 MoE grouped GEMM `w2` shapes when H20 tuning enables TMA, especially `dsv4-pro TP8 shape_m=512` where routed GEMM M is `512 * top_k = 3072`.

## Root Cause

The TMA BS load writes into `smem.bs`.

Before this change, `SharedStorage` only aligned the enclosing union to 128 bytes. Some preceding shared-memory fields, such as grouped input scale `as`, can have sizes that are not multiples of 128 bytes. This can place `bs` at a non-128-byte offset even though the overall union is aligned.

For example, some H20 MoE `w2` configs place `smem.bs` at `64 mod 128`, and the TMA load into that shared-memory address fails with `CUDA_ERROR_MISALIGNED_ADDRESS`.

This is not caused by global tensor pointer alignment or K-tile divisibility.

## Changes

- Add `alignas(128)` to shared-memory arrays that can be used as TMA destinations:
  - `a`
  - `b`
  - `bs`
  - `bzp`
  - `bs_c`
  - `bias`

