### PR TITLE
tune(sm90_h20): size small-K MoE down-gemm grid by tile count

### DIFF
--- a/humming/tune/sm90_h20.py
+++ b/humming/tune/sm90_h20.py
@@ -195,6 +195,18 @@ class Sm90H20Heuristics(DeviceHeuristics):
                 config["use_tma_a"] = False
                 config["use_tma_c"] = False
 
+            # Small-K MoE down-gemm: size the persistent grid for ~5 output tiles
+            # per CTA — here num_sms is the grid factor (a launch param, GEMM
+            # bit-identical) and is intentionally set above the physical SM count.
+            if config["num_ctas_per_sm"] > 1 and shape_m >= 24576:
+                tiles_per_cta = 5
+                block_m, block_n, _ = config["block_shape"]
+                num_tiles = (meta.shape_n // block_n) * (shape_m // block_m)
+                sms_target = num_tiles / (config["num_ctas_per_sm"] * tiles_per_cta)
+                config["num_sms"] = max(
+                    config["num_sms"], 1 << round(math.log2(sms_target))
+                )
+
         if block_shape_m >= 48 and num_ctas_per_sm <= 2 and num_warps <= 8 and not is_moe:
             config["use_tma"] = True
             config["use_warp_spec"] = True


### PR DESCRIPTION
The MoE down-projection GEMM has a small contraction dim (K = intermediate size / TP, typically 256-384). It runs the persistent kernel with num_sms = device SM count, which gives each CTA far more output tiles than ideal — the per-tile prologue/epilogue latency is exposed and never overlapped across tiles.

Size num_sms from the tile count so each CTA gets ~5 output tiles. This spreads the work over more CTA waves; the waves desync and the hardware overlaps one CTA's tile-boundary stall with another's compute. num_sms is derived from (N/block_n)*(M/block_m) so it auto-scales with N, and is power-of-two quantised to keep the heuristic's bucket table coarse. num_sms is a launch parameter only — no kernel recompile, GEMM result bit-identical.

Gated to routed M >= 24576 (measured onset of benefit) and the persistent multi-CTA path; below it the default grid is already optimal.

Measured on H20-3e, DSV4 MXFP4 W4A8 down-gemm, fix vs default:
  DSV4-Flash (N=4096, K=256): routed M 24k/49k/98k  -1.9 / -2.6 / -3.7%
  DSV4-Pro   (N=7168, K=384): routed M 24k/49k/98k  -3.3 / -3.8 / -5.6%
NCU confirms the mechanism: occupancy unchanged, SM throughput +2.5pp,
barrier stall -2.5pp, no new bottleneck.