### PR TITLE
fix: actual_shape_m computation

### DIFF
--- a/benchmarks/bench_humming.py
+++ b/benchmarks/bench_humming.py
@@ -63,7 +63,7 @@ def bench_humming(
         if gemm_type == GemmType.DENSE:
             actual_shape_m = shape_m
         elif gemm_type == GemmType.INDEXED:
-            actual_shape_m = shape_m * (1 if is_moe_down else top_k)
+            actual_shape_m = shape_m * (top_k if is_moe_down else 1)
         elif gemm_type == GemmType.GROUPED_CONTIGUOUS:
             actual_shape_m = shape_m * top_k
         else:


### PR DESCRIPTION
hi. 
Fixes the `actual_shape_m` calculation for indexed GEMM benchmarks.
MoE down-gemm should expand the input M dimension by `top_k`, while the non-down path should keep the original `shape_m`, so the benchmark now uses the correct input size for each path.

cc @jinzhen-lin 