### PR TITLE
fix(mainloop): restore kNumBSPerSubBlock operator precedence

### DIFF
--- a/humming/include/humming/arith/mainloop_arith.cuh
+++ b/humming/include/humming/arith/mainloop_arith.cuh
@@ -46,7 +46,7 @@ private:
   static constexpr uint32_t kNumSubBlocksM = CEIL_DIV(WarpShape::M, 16);
   static constexpr uint32_t kNumSubBlocksN = WarpShape::N / 16;
   static constexpr uint32_t kNumASPerSubBlock = kUseWgmma ? 4 : 2;
-  static constexpr uint32_t kNumBSPerSubBlock = !kUseFusedE8m0Scale && (!kUseWgmma && ElementA::kBits) < 16 ? 4 : 2;
+  static constexpr uint32_t kNumBSPerSubBlock = !kUseFusedE8m0Scale && !kUseWgmma && ElementA::kBits < 16 ? 4 : 2;
   static constexpr uint32_t kNumASPerGroup = kNumSubBlocksM * kNumASPerSubBlock;
   static constexpr uint32_t kNumBSPerGroup = kNumSubBlocksN * kNumBSPerSubBlock;
 

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -19,6 +19,7 @@ from humming.utils.weight import (
     "b_dtype",
     [
         "uint3",
+        "uint4",
         "uint5",
         "uint8",
         "int4",


### PR DESCRIPTION
1. kNumBSPerSubBlock was regressed in ad5b68c ("add fused e8m0 scale support"): `!kUseFusedE8m0Scale && (!kUseWgmma && ElementA::kBits) < 16` parenthesizes `(!kUseWgmma && ElementA::kBits)` into a bool and then compares it to 16 (always true), collapsing the predicate to `!kUseFusedE8m0Scale ? 4 : 2` and dropping the intended wgmma / bit-width guard. Restore the pre-ad5b68c logic `!kUseWgmma && ElementA::kBits < 16`; for W*A16 this brings kNumBSPerSubBlock back from 4 to 2 (smaller bs/dq_bs scratch).

2. Also add uint4 to test_scale's b_dtype matrix — W4A16, the most common 4-bit weight config, was missing from correctness coverage.