### PR TITLE
[fix] use routed token count for grouped_masked benchmark dispatch

### DIFF
--- a/benchmarks/bench_humming.py
+++ b/benchmarks/bench_humming.py
@@ -114,6 +114,9 @@ def bench_humming(
             _, expert_layout, sorted_ids, expert_ids, num_tokens_padded = moe_tensors
 
         def run():
+            valid_shape_m = 0
+            if gemm_type == GemmType.GROUPED_MASKED:
+                valid_shape_m = shape_m * top_k
             return layer(
                 inputs=inputs,  # noqa
                 input_scale=input_scale,  # noqa
@@ -121,6 +124,7 @@ def bench_humming(
                 expert_ids=expert_ids,  # noqa
                 num_tokens_padded=num_tokens_padded,  # noqa
                 expert_layout=expert_layout,  # noqa
+                valid_shape_m=valid_shape_m,
                 compute_config=json.dumps(
                     {
                         "use_f16_accum": use_f16_accum,
@@ -143,6 +147,14 @@ def bench_humming(
         for tensor in layer.state_dict().values():
             if gemm_type == GemmType.DENSE:
                 nbytes += tensor.nbytes
+            elif gemm_type == GemmType.GROUPED_MASKED:
+                assert expert_layout is not None
+                num_actived_experts = int((expert_layout > 0).sum().item())
+                nbytes += tensor.nbytes // num_experts * num_actived_experts
+            elif gemm_type == GemmType.GROUPED_CONTIGUOUS:
+                assert expert_layout is not None
+                num_actived_experts = int((expert_layout[1:] > expert_layout[:-1]).sum().item())
+                nbytes += tensor.nbytes // num_experts * num_actived_experts
             else:
                 assert expert_ids is not None
                 num_actived_experts = len(set(expert_ids.tolist()))

--- a/humming/layer.py
+++ b/humming/layer.py
@@ -809,6 +809,7 @@ class HummingLayer(HummingModule):
         num_tokens_padded: torch.Tensor | None = None,
         expert_layout: torch.Tensor | None = None,
         top_k: int = 1,
+        valid_shape_m: int = 0,
         compute_config: dict | str | None = None,
         tuning_config: dict | list | str | None = None,
     ) -> torch.Tensor:
@@ -822,6 +823,7 @@ class HummingLayer(HummingModule):
             num_tokens_padded=num_tokens_padded,
             expert_layout=expert_layout,
             top_k=top_k,
+            valid_shape_m=valid_shape_m,
             compute_config=compute_config,
             tuning_config=tuning_config,
         )


### PR DESCRIPTION
## Summary

Fixes a `grouped_masked` benchmark dispatch issue where `expert_max_tokens` was unintentionally driving kernel config selection.

For `grouped_masked`, the physical input M is the masked-layout capacity:

```text
num_experts * expert_max_tokens
```

but the actual routed workload is:

```text
shape_m * top_k
```

The launcher selects the tuning config via `find_kernel_launch_data(configs, valid_shape_m)`. When `valid_shape_m <= 0` it falls back to `a.size(0) * top_k` only for the contiguous/indexed gemm type (`gemm_type_id == 1`); for `grouped_masked` it ends up using the padded capacity `a.size(0)` directly. So bumping `expert_max_tokens` from 32 to 64 changed the selected tile even though the real routed token count was unchanged. On B200 w4a16 `grouped_masked` this made the 64-token-capacity case pick a slower config and roughly double runtime.

The fix passes `valid_shape_m = shape_m * top_k` for `grouped_masked` benchmark runs. The kernel still receives the original padded input shape for masked-layout addressing; only config selection uses the routed token count.

## Changes

- Expose `valid_shape_m` on `HummingLayer.forward()` and forward it to the existing lower-level `forward_layer` / `humming_gemm` path (the param was already plumbed through `ops` and the C++ launcher; this just wires up the public entry point).
- In `bench_humming.py`, pass `valid_shape_m = shape_m * top_k` for `grouped_masked`.
- Add grouped GEMM memory accounting for the GBps metric:
  - `grouped_masked`: active experts from `expert_layout > 0`
  - `grouped_contiguous`: active experts from `expert_layout` offset deltas
  - `indexed` (existing `else`): active experts from `expert_ids`

## Validation

```
PYTHONPATH=. pytest -q tests/test_moe.py::test_grouped_gemm
900 passed
```

`grouped_contiguous` was checked for the same class of issue. It doesn't need a `valid_shape_m` override because its physical input M is already `shape_m * top_k`, matching the routed token count used for config selection.