### PR TITLE
[fix] bench_marlin topk_weights dereference

### DIFF
--- a/benchmarks/bench_marlin.py
+++ b/benchmarks/bench_marlin.py
@@ -98,6 +98,15 @@ def bench_marlin(
             )
             _, _, sorted_ids, expert_ids, num_tokens_padded = moe_tensors
 
+            # The marlin kernel always dereferences topk_weights (it does not
+            # check for a null pointer), so pass a real tensor even though
+            # mul_topk_weights=False means the values are unused.
+            topk_weights = torch.ones(
+                (shape_m, top_k),
+                dtype=torch.float32,
+                device="cuda:0",
+            )
+
         def run_dense():
             return vllm_ops.marlin_gemm(
                 a=inputs,  # noqa
@@ -134,7 +143,7 @@ def bench_marlin(
                 sorted_token_ids=sorted_ids,  # noqa
                 expert_ids=expert_ids,  # noqa
                 num_tokens_past_padded=num_tokens_padded,  # noqa
-                topk_weights=None,  # noqa
+                topk_weights=topk_weights,  # noqa
                 mul_topk_weights=False,
                 b_q_type=vllm_scalar_type,
                 size_m=inputs.size(0),  # noqa


### PR DESCRIPTION
The marlin kernel always dereferences `topk_weights`. This crashes when `topk_weights` is None.

```
$ PYTHONPATH=. python benchmarks/bench_marlin.py \
    --shape_n 4096 --shape_k 7168 --top_k 8 \
    --a_dtype bfloat16 --b_dtype int4 \
    --bs_dtype bfloat16 --c_dtype bfloat16 \
    --weight_scale_group_size 32 \
    --num_experts 32 \
    --shape_m_list 20 30 40 50 100 150 200
  0%|                                                                                                                                       | 0/7 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/work/code/humming_test/benchmarks/bench_marlin.py", line 230, in <module>
    main()
  File "/work/code/humming_test/benchmarks/bench_marlin.py", line 199, in main
    benchmark_result = bench_marlin(
                       ^^^^^^^^^^^^^
  File "/work/code/humming_test/benchmarks/bench_marlin.py", line 152, in bench_marlin
    outputs = run()
              ^^^^^
  File "/work/code/humming_test/benchmarks/bench_marlin.py", line 122, in run_moe
    return vllm_ops.moe_wna16_marlin_gemm(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/code/vllm/.venv/lib/python3.12/site-packages/vllm/_custom_ops.py", line 2624, in moe_wna16_marlin_gemm
    return torch.ops._moe_C.moe_wna16_marlin_gemm(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/code/vllm/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1269, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Cannot access data pointer of Tensor that doesn't have storage
```

