### PR TITLE
Support per-token-group input scale in fused-E8M0 GEMM

### DIFF
--- a/humming/include/humming/arith/mainloop_arith.cuh
+++ b/humming/include/humming/arith/mainloop_arith.cuh
@@ -205,10 +205,12 @@ public:
     uint32_t k_index = iter_id * kPartMmaShapeK + (k + 1) * MmaShape::K;
     uint32_t is_last_iter = iter_id == (kWarpItersK - 1);
     uint32_t is_as_group_end = kIsGroupInputScale && k_index % kInputScaleGroupSize == 0;
-    uint32_t is_bs_group_end = (kIsGroupWeightScale || kIsBlockWeightScale) && k_index % kWeightScaleGroupSize == 0;
+    constexpr bool kProcessGroupWeightScale = kIsGroupWeightScale && !kUseFusedE8m0Scale;
+    constexpr bool kProcessBlockWeightScale = kIsBlockWeightScale && !kUseFusedE8m0Scale;
+    uint32_t is_bs_group_end = (kProcessGroupWeightScale || kProcessBlockWeightScale) && k_index % kWeightScaleGroupSize == 0;
 
     bool should_apply_as = kIsGroupInputScale && (is_last_iter || is_as_group_end);
-    bool should_apply_bs = (kIsGroupWeightScale || kIsBlockWeightScale) && (is_last_iter || is_bs_group_end);
+    bool should_apply_bs = (kProcessGroupWeightScale || kProcessBlockWeightScale) && (is_last_iter || is_bs_group_end);
     if (!should_apply_as && !should_apply_bs) return;
 
     if (m == 0 && n == 0 && should_apply_as) {
@@ -315,7 +317,10 @@ public:
     if constexpr (ElementA::kBits == 16) return;
     if constexpr (!kIsGroupInputScale && !kIsGroupWeightScale && !kIsBlockWeightScale) return;
     if constexpr (kUseWgmma) return;
-    if constexpr (kUseFusedE8m0Scale) return;
+    constexpr bool kApplyGroupWeightScaleOnC = kIsGroupWeightScale && !kUseFusedE8m0Scale;
+    constexpr bool kApplyBlockWeightScaleOnC = kIsBlockWeightScale && !kUseFusedE8m0Scale;
+    constexpr bool kApplyGroupInputScaleOnC = kIsGroupInputScale;
+    if constexpr (kUseFusedE8m0Scale && !kApplyGroupInputScaleOnC) return;
 
     may_process_as_and_bs_before_apply_on_c(m, n, k, iter_id);
 
@@ -323,11 +328,11 @@ public:
     uint32_t buffer_id = iter_id % 2;
     uint32_t k_index = iter_id * kPartMmaShapeK + (k + 1) * MmaShape::K;
     uint32_t is_last_iter = iter_id == (kWarpItersK - 1);
-    uint32_t is_as_group_end = kIsGroupInputScale && k_index % kInputScaleGroupSize == 0;
-    uint32_t is_bs_group_end = (kIsGroupWeightScale || kIsBlockWeightScale) && k_index % kWeightScaleGroupSize == 0;
+    uint32_t is_as_group_end = kApplyGroupInputScaleOnC && k_index % kInputScaleGroupSize == 0;
+    uint32_t is_bs_group_end = (kApplyGroupWeightScaleOnC || kApplyBlockWeightScaleOnC) && k_index % kWeightScaleGroupSize == 0;
 
-    bool should_apply_as = kIsGroupInputScale && (is_last_iter || is_as_group_end);
-    bool should_apply_bs = (kIsGroupWeightScale || kIsBlockWeightScale) && (is_last_iter || is_bs_group_end);
+    bool should_apply_as = kApplyGroupInputScaleOnC && (is_last_iter || is_as_group_end);
+    bool should_apply_bs = (kApplyGroupWeightScaleOnC || kApplyBlockWeightScaleOnC) && (is_last_iter || is_bs_group_end);
     if (!should_apply_as && !should_apply_bs) return;
 
     using CRegistersArrayType = typename MmaOpClass::CRegisters[2][WarpShape::M / MmaShape::M][WarpShape::N / MmaShape::N];
@@ -352,13 +357,13 @@ public:
           bs_val = reinterpret_cast<scalar_t2 *>(bs[buffer_id])[n * MmaShape::N / 8 + inner_n];
         }
 
-        if constexpr (kIsGroupInputScale && kIsGroupWeightScale) {
+        if constexpr (kApplyGroupInputScaleOnC && kApplyGroupWeightScaleOnC) {
           part_regs_c1 = __hfma2(part_regs_c0, __hmul2(as_val, bs_val), part_regs_c1);
-        } else if constexpr (!kIsGroupInputScale && kIsGroupWeightScale) {
+        } else if constexpr (!kApplyGroupInputScaleOnC && kApplyGroupWeightScaleOnC) {
           part_regs_c1 = __hfma2(part_regs_c0, bs_val, part_regs_c1);
-        } else if constexpr (!kIsGroupInputScale && kIsBlockWeightScale) {
+        } else if constexpr (!kApplyGroupInputScaleOnC && kApplyBlockWeightScaleOnC) {
           part_regs_c1 = __hfma2(part_regs_c0, bs_val, part_regs_c1);
-        } else if constexpr (kIsGroupInputScale && !kIsGroupWeightScale) {
+        } else if constexpr (kApplyGroupInputScaleOnC && !kApplyGroupWeightScaleOnC) {
           part_regs_c1 = __hfma2(part_regs_c0, as_val, part_regs_c1);
         }
         reinterpret_cast<uint32_t *>(&part_regs_c0)[0] = 0;
@@ -390,16 +395,16 @@ public:
           float2 &bs_vals = reinterpret_cast<float2 *>(dq_bs)[n * MmaShape::N / 8 + inner_n];
           float &block_bs_float = reinterpret_cast<float *>(&bs[buffer_id])[0];
 
-          if constexpr (kIsGroupInputScale && kIsGroupWeightScale) {
+          if constexpr (kApplyGroupInputScaleOnC && kApplyGroupWeightScaleOnC) {
             part_regs_c1.x += as_val * bs_vals.x * part_regs_c0.x;
             part_regs_c1.y += as_val * bs_vals.y * part_regs_c0.y;
-          } else if constexpr (!kIsGroupInputScale && kIsGroupWeightScale) {
+          } else if constexpr (!kApplyGroupInputScaleOnC && kApplyGroupWeightScaleOnC) {
             part_regs_c1.x += bs_vals.x * part_regs_c0.x;
             part_regs_c1.y += bs_vals.y * part_regs_c0.y;
-          } else if constexpr (!kIsGroupInputScale && kIsBlockWeightScale) {
+          } else if constexpr (!kApplyGroupInputScaleOnC && kApplyBlockWeightScaleOnC) {
             part_regs_c1.x += block_bs_float * part_regs_c0.x;
             part_regs_c1.y += block_bs_float * part_regs_c0.y;
-          } else if constexpr (kIsGroupInputScale && !kIsGroupWeightScale) {
+          } else if constexpr (kApplyGroupInputScaleOnC && !kApplyGroupWeightScaleOnC) {
             part_regs_c1.x += as_val * part_regs_c0.x;
             part_regs_c1.y += as_val * part_regs_c0.y;
           }
@@ -416,7 +421,10 @@ public:
     if constexpr (ElementA::kBits == 16) return;
     if constexpr (!kIsGroupInputScale && !kIsGroupWeightScale && !kIsBlockWeightScale) return;
     if constexpr (!kUseWgmma) return;
-    if constexpr (kUseFusedE8m0Scale) return;
+    constexpr bool kApplyGroupWeightScaleOnC = kIsGroupWeightScale && !kUseFusedE8m0Scale;
+    constexpr bool kApplyBlockWeightScaleOnC = kIsBlockWeightScale && !kUseFusedE8m0Scale;
+    constexpr bool kApplyGroupInputScaleOnC = kIsGroupInputScale;
+    if constexpr (kUseFusedE8m0Scale && !kApplyGroupInputScaleOnC) return;
 
     may_process_as_and_bs_before_apply_on_c(m, 0, k, iter_id);
 
@@ -424,11 +432,11 @@ public:
     uint32_t buffer_id = iter_id % 2;
     uint32_t k_index = iter_id * kPartMmaShapeK + (k + 1) * MmaShape::K;
     uint32_t is_last_iter = iter_id == (kWarpItersK - 1);
-    uint32_t is_as_group_end = kIsGroupInputScale && k_index % kInputScaleGroupSize == 0;
-    uint32_t is_bs_group_end = (kIsGroupWeightScale || kIsBlockWeightScale) && k_index % kWeightScaleGroupSize == 0;
+    uint32_t is_as_group_end = kApplyGroupInputScaleOnC && k_index % kInputScaleGroupSize == 0;
+    uint32_t is_bs_group_end = (kApplyGroupWeightScaleOnC || kApplyBlockWeightScaleOnC) && k_index % kWeightScaleGroupSize == 0;
 
-    bool should_apply_as = kIsGroupInputScale && (is_last_iter || is_as_group_end);
-    bool should_apply_bs = (kIsGroupWeightScale || kIsBlockWeightScale) && (is_last_iter || is_bs_group_end);
+    bool should_apply_as = kApplyGroupInputScaleOnC && (is_last_iter || is_as_group_end);
+    bool should_apply_bs = (kApplyGroupWeightScaleOnC || kApplyBlockWeightScaleOnC) && (is_last_iter || is_bs_group_end);
     if (!should_apply_as && !should_apply_bs) return;
 
     using CRegistersArrayType = typename MmaOpClass::CRegisters[2][WarpShape::N * 4 / MmaShape::N][WarpShape::M / MmaShape::M];
@@ -455,13 +463,13 @@ public:
 
         float &block_bs_float = reinterpret_cast<float *>(&bs[buffer_id])[0];
 
-        if constexpr (kIsGroupInputScale && kIsGroupWeightScale) {
+        if constexpr (kApplyGroupInputScaleOnC && kApplyGroupWeightScaleOnC) {
           part_regs_c1 = __hfma2(part_regs_c0, __hmul2(as_val, bs_val), part_regs_c1);
-        } else if constexpr (!kIsGroupInputScale && kIsGroupWeightScale) {
+        } else if constexpr (!kApplyGroupInputScaleOnC && kApplyGroupWeightScaleOnC) {
           part_regs_c1 = __hfma2(part_regs_c0, bs_val, part_regs_c1);
-        } else if constexpr (!kIsGroupInputScale && kIsBlockWeightScale) {
+        } else if constexpr (!kApplyGroupInputScaleOnC && kApplyBlockWeightScaleOnC) {
           part_regs_c1 = __hfma2(part_regs_c0, bs_val, part_regs_c1);
-        } else if constexpr (kIsGroupInputScale && !kIsGroupWeightScale) {
+        } else if constexpr (kApplyGroupInputScaleOnC && !kApplyGroupWeightScaleOnC) {
           part_regs_c1 = __hfma2(part_regs_c0, as_val, part_regs_c1);
         }
       } else {
@@ -478,16 +486,16 @@ public:
         float &bs_val = reinterpret_cast<float *>(dq_bs)[m * 2 + inner_m];
         float &block_bs_float = reinterpret_cast<float *>(&bs[buffer_id])[0];
 
-        if constexpr (kIsGroupInputScale && kIsGroupWeightScale) {
+        if constexpr (kApplyGroupInputScaleOnC && kApplyGroupWeightScaleOnC) {
           part_regs_c1.x += as_vals.x * bs_val * part_regs_c0.x;
           part_regs_c1.y += as_vals.y * bs_val * part_regs_c0.y;
-        } else if constexpr (!kIsGroupInputScale && kIsGroupWeightScale) {
+        } else if constexpr (!kApplyGroupInputScaleOnC && kApplyGroupWeightScaleOnC) {
           part_regs_c1.x += bs_val * part_regs_c0.x;
           part_regs_c1.y += bs_val * part_regs_c0.y;
-        } else if constexpr (!kIsGroupInputScale && kIsBlockWeightScale) {
+        } else if constexpr (!kApplyGroupInputScaleOnC && kApplyBlockWeightScaleOnC) {
           part_regs_c1.x += block_bs_float * part_regs_c0.x;
           part_regs_c1.y += block_bs_float * part_regs_c0.y;
-        } else if constexpr (kIsGroupInputScale && !kIsGroupWeightScale) {
+        } else if constexpr (kApplyGroupInputScaleOnC && !kApplyGroupWeightScaleOnC) {
           part_regs_c1.x += as_vals.x * part_regs_c0.x;
           part_regs_c1.y += as_vals.y * part_regs_c0.y;
         }

--- a/humming/include/humming/mma/wgmma.cuh
+++ b/humming/include/humming/mma/wgmma.cuh
@@ -114,9 +114,12 @@ public:
       constexpr uint32_t kNumIters = WarpShape::N / (MmaShape::N / 4);
 
       bool scale_d = true;
-      constexpr bool kApplyScaleOnC = !kUseFusedE8m0Scale && ElementA::kBits != 16 &&
-          (LayerConfig::kInputScaleGroupSize > 0 || LayerConfig::kWeightScaleGroupSize > 0);
-      if constexpr (!kUseFusedE8m0Scale && ElementA::kBits != 16 && LayerConfig::kInputScaleGroupSize > 0) {
+      constexpr bool kFusedGroupInputScale =
+          kUseFusedE8m0Scale && ElementA::kBits != 16 && LayerConfig::kInputScaleGroupSize > 0;
+      constexpr bool kApplyScaleOnC = (!kUseFusedE8m0Scale && ElementA::kBits != 16 &&
+          (LayerConfig::kInputScaleGroupSize > 0 || LayerConfig::kWeightScaleGroupSize > 0))
+          || kFusedGroupInputScale;
+      if constexpr (ElementA::kBits != 16 && LayerConfig::kInputScaleGroupSize > 0) {
         scale_d = (iter_id * kPartMmaShapeK) % LayerConfig::kInputScaleGroupSize > 0;
       }
       if constexpr (!kUseFusedE8m0Scale && ElementA::kBits != 16 && LayerConfig::kWeightScaleGroupSize > 0) {
@@ -165,7 +168,7 @@ public:
     constexpr bool kIsGroupWeightScale = LayerConfig::kIsGroupWeightScale;
     constexpr bool kIsBlockWeightScale = LayerConfig::kIsBlockWeightScale;
 
-    if constexpr (ElementA::kBits < 16 && !kUseFusedE8m0Scale && kIsGroupInputScale) {
+    if constexpr (ElementA::kBits < 16 && kIsGroupInputScale) {
       index = 1;
     }
 

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -404,10 +404,14 @@ def test_int_weight_scale(
 @pytest.mark.parametrize("c_dtype", ["float16", "bfloat16"])
 @pytest.mark.parametrize("weight_scale_group_size", [32, 64])
 @pytest.mark.parametrize("has_global_scale", [True, False])
-def test_fused_e8m0_weight_scale(c_dtype, weight_scale_group_size, has_global_scale):
+@pytest.mark.parametrize("input_scale_group_size", [0, 128])
+@pytest.mark.parametrize("mma_type", ["mma", "wgmma"])
+def test_fused_e8m0_weight_scale(
+    c_dtype, weight_scale_group_size, has_global_scale, input_scale_group_size, mma_type
+):
     a_dtype = dtypes.float8e4m3
     b_dtype = dtypes.float4e2m1
-    skip_if_unsupported(a_dtype=a_dtype)
+    skip_if_unsupported(a_dtype=a_dtype, mma_type=mma_type)
     c_dtype = dtypes.DataType.from_str(c_dtype)
     bs_dtype = dtypes.float8e8m0
 
@@ -451,6 +455,7 @@ def test_fused_e8m0_weight_scale(c_dtype, weight_scale_group_size, has_global_sc
     _, inputs_ref, inputs, input_scale = generate_random_inputs(
         m=1024,
         k=1024,
+        group_size=input_scale_group_size,
         dtype=a_dtype,
     )
 
@@ -465,12 +470,13 @@ def test_fused_e8m0_weight_scale(c_dtype, weight_scale_group_size, has_global_sc
         bs_dtype=bs_dtype,
         num_stages=3,
         use_warp_spec=False,
+        input_scale_group_size=input_scale_group_size,
         weight_scale_group_size=weight_scale_group_size,
         weight_scale_type="group_tensor",
         use_fused_e8m0_scale=True,
         use_tma=False,
         use_cp_async=False,
-        mma_type="mma",
+        mma_type=mma_type,
         use_stream_k=False,
     )
 


### PR DESCRIPTION
# Support per-token-group input scale in the fused-E8M0 GEMM

## Summary

The fused-E8M0 MXFP4 W4A8 GEMM currently supports only a **single per-tensor input scale**. This PR lets it also consume a **per-token-group input scale** (the layout produced by per-token-group FP8 activation quantization, e.g. FP8 E4M3 with a 128-element K group), while keeping the fused weight-scale decode intact.

Motivation: MoE serving stacks increasingly feed activations that are already quantized at per-token-group granularity. For example, expert dispatch via DeepEP delivers each expert its tokens as FP8 with a per-token, per-128-K-group scale — there is no per-tensor activation scale to hand to the kernel. Such workloads therefore cannot use the fused-E8M0 kernel today: the fused path ignores the per-group input scale and produces wrong results, forcing them onto the slower non-fused group-scale path. With this change the fused path is numerically correct for a per-group input scale, so these MoE GEMMs can use it directly.

## What changes

The non-fused path already implements per-group input scale: it segments the WGMMA accumulator at input-scale-group boundaries (`scale_d`), accumulates each group's partial product into a temp buffer, and folds it into the final buffer scaled by the group's input scale `as`. The fused path reused none of this because it early-returned before the scale-on-C step. This PR enables that same machinery for the fused path — the weight scale is already folded into the decode, so only the input scale is applied.

Changes (WGMMA path only; the MMA path keeps its existing fused early-return):

- `mma/wgmma.cuh::run` — `scale_d` now segments the accumulator at input-scale-group boundaries for the fused path too. The weight-scale-group boundary handling stays non-fused-only, since fused already folded the weight scale into the decode. `kApplyScaleOnC` and `final_regs_c_as_ptr()` select the scaled accumulator buffer when fused carries a per-group input scale.
- `arith/mainloop_arith.cuh::may_apply_as_and_bs_on_wgmma_c` — no longer early-returns for the fused path when a per-group input scale is present. New compile-time flags route the fused path to the "apply input scale only" arm; the weight-scale (`bs`) preprocessing is gated off the fused path so it never touches the unused `dq_bs` buffer.

No new tensors or shared-memory buffers are needed: the per-group `as` buffer, its g2s/s2r loaders, and the double-buffered accumulator are already allocated whenever the input-scale group size is set — the fused path simply did not consume them.

## Testing

`tests/test_fused_e8m0_input_scale.py` (new): fused-E8M0 weight scale + per-token-group-128 FP8 input scale, compared against a torch reference, parametrized over `shape_m ∈ {64, 128, 512}`, `warp_n ∈ {16, 32}`, `num_stages ∈ {3, 4}` — 12 cases, all passing (mean relative error < 0.01).

Existing paths are unaffected: the non-fused group-scale WGMMA path still matches its torch reference (rel ~1e-5); only the fused branch takes the new code.

## Notes

- Verified on SM90 (H20).
- Correct for `num_stages >= 3` (the depths the tuner emits for these shapes); `num_stages <= 2` for fused + per-group input scale is a pre-existing limitation of the fused accumulator flow, unchanged by this PR.
- The MMA (non-WGMMA) fused path is left with its original per-tensor-only behavior; the targeted configs use WGMMA.

## Files

- `humming/include/humming/mma/wgmma.cuh`
- `humming/include/humming/arith/mainloop_arith.cuh`
- `tests/test_fused_e8m0_input_scale.py`
