### PR TITLE
fix: correct UE8M0 scale rounding and zero-point writes

### DIFF
--- a/humming/include/humming/kernel/quant_weight.cuh
+++ b/humming/include/humming/kernel/quant_weight.cuh
@@ -223,9 +223,9 @@ __global__ void quant_weight(uint4 *in_ptr, uint4 *out_ptr, uint32_t *out_scale_
     }
 
     if constexpr (kUseUE8M0Scale) {
-      uint32_t scale_val_uint = *reinterpret_cast<uint32_t *>(&scale_val);
-      scale_val_uint = (scale_val_uint & 0x7F800000) + 1;
-      scale_val = *reinterpret_cast<float *>(&scale_val);
+      uint32_t scale_val_uint = __float_as_uint(scale_val);
+      scale_val_uint = (scale_val_uint + 0x007FFFFF) & 0x7F800000;
+      scale_val = __uint_as_float(scale_val_uint);
     }
 
     if (threadIdx.x == 0) {
@@ -241,8 +241,8 @@ __global__ void quant_weight(uint4 *in_ptr, uint4 *out_ptr, uint32_t *out_scale_
 
       if constexpr (kHasZeroPoint && !kIsFpZeroPoint) {
         zero_point_ptr[blockIdx.x] = static_cast<uint32_t>(zero_point);
-      } else {
-        zero_point_ptr[blockIdx.x] = *reinterpret_cast<uint32_t *>(&zero_point_float);
+      } else if constexpr (kHasZeroPoint && kIsFpZeroPoint) {
+        zero_point_ptr[blockIdx.x] = __float_as_uint(zero_point_float);
       }
     }
   } else {


### PR DESCRIPTION
## Summary

- Round FP32 scales up to the next UE8M0-representable power of two before quantization.
- Avoid writing `zero_point_ptr` when `kHasZeroPoint` is false.

