### PR TITLE
Fix bias loader, A-multicast guard, and 1-bit symmetric scale

### DIFF
--- a/humming/include/humming/kernel/quant_weight.cuh
+++ b/humming/include/humming/kernel/quant_weight.cuh
@@ -208,8 +208,17 @@ __global__ void quant_weight(uint4 *in_ptr, uint4 *out_ptr, uint32_t *out_scale_
     } else if constexpr (!kHasZeroPoint) {
       float min_abs_val = fminf(max_val, fabsf(min_val));
       float dtype_max_val = get_data_type_max_num<TargetType>();
-      float scale_val1 = max_abs_val / (dtype_max_val + 1.0);
-      float scale_val2 = min_abs_val / (dtype_max_val + 0.0);
+      float scale_val1, scale_val2;
+      if constexpr (TargetType::kBits == 1) {
+        // 1-bit has no positive code (dtype_max_val == 0) and
+        // quant_buffer does not clamp: pick a scale that rounds the
+        // positive side to code 0 and the negative side to code -1.
+        scale_val1 = max_abs_val / (dtype_max_val + 1.499);
+        scale_val2 = min_abs_val / (dtype_max_val + 0.499);
+      } else {
+        scale_val1 = max_abs_val / (dtype_max_val + 1.0);
+        scale_val2 = min_abs_val / (dtype_max_val + 0.0);
+      }
 
       scale_val = max(scale_val1, scale_val2);
       if (max_val > fabsf(min_val)) scale_val = -scale_val;

--- a/humming/include/humming/memory/g2s_loader/loader_a.cuh
+++ b/humming/include/humming/memory/g2s_loader/loader_a.cuh
@@ -68,7 +68,7 @@ public:
       const uint32_t col_offset2 = col_offset + (1024 / ElementA::kBits) * block_idx;
       if constexpr (kMultiCastSizeA == 1) {
         tma_load_2d(tensor_map_ptr, smem_ptr + smem_offset, mbar_ptr, col_offset2, row_offset);
-      } else if (ctx.cluster_rank == 0) {
+      } else if (blockIdx.x % kMultiCastSizeA == 0) {
         tma_load_2d<kMultiCastSizeA>(tensor_map_ptr, smem_ptr + smem_offset, mbar_ptr, col_offset2, row_offset);
       }
     }

--- a/humming/include/humming/memory/s2r_loader/loader_bias.cuh
+++ b/humming/include/humming/memory/s2r_loader/loader_bias.cuh
@@ -16,6 +16,7 @@ public:
   CUDA_INLINE
   void load(const int4 *smem_ptr, uint32_t *regs_ptr, uint32_t pred) {
     uint32_t warp_id = ctx.warp_id();
+    uint32_t n_warp_id = ctx.n_warp_id();
     uint32_t lane_id = ctx.lane_id();
     uint32_t bias_sh_rd = Ctx::kUseWgmma ? (lane_id / 8) : (lane_id % 4);
 


### PR DESCRIPTION
While working on tcgen05 support, I found a few issues:

* Bias S2R loader: restore missing n_warp_id binding so has_bias kernels compile after the Ctx refactor in 04d139b.
* TMA-A multicast: call the A-dimension leader check (blockIdx.x % kMultiCastSizeA == 0) instead of comparing the unbound ctx.cluster_rank member.
* 1-bit symmetric quant: restore the historical 1.499 / 0.499 divisors so scale isn’t divide-by-zero when dtype_max_val == 0.
