### PR TITLE
Fix CompressedTensorsInputSchema to accept pack-quantized format

### DIFF
--- a/humming/schema/compressed_tensors.py
+++ b/humming/schema/compressed_tensors.py
@@ -270,6 +270,7 @@ class CompressedTensorsInputSchema(BaseInputSchema):
             "int-quantized",
             "float-quantized",
             "naive-quantized",
+            "pack-quantized",
             "nvfp4-pack-quantized",
             "mxfp4-pack-quantized",
         ]


### PR DESCRIPTION
## Summary
need to enable pack-quantized for CT in humming or else we can't do activation quantization in vllm

🤖 Generated with [Claude Code](https://claude.com/claude-code)