### PR TITLE
heuristic: cap CTAs at 2 for large-M grouped-input-scale GEMMs on H20

### DIFF
--- a/humming/tune/sm90_h20.py
+++ b/humming/tune/sm90_h20.py
@@ -198,6 +198,14 @@ class Sm90H20Heuristics(DeviceHeuristics):
             block_shape_k = block_shape_k // 2
             assert block_shape_k >= warp_shape_k
 
+        if (
+            meta.a_dtype.num_bits == 8
+            and meta.input_scale_group_size > 0
+            and gemm_type != GemmType.GROUPED_MASKED
+            and shape_m >= 6144
+        ):
+            num_ctas_per_sm = min(num_ctas_per_sm, 2)
+
         config = {
             "block_shape": (block_shape_m, block_shape_n, block_shape_k),
             "warp_shape": (warp_shape_m, warp_shape_n, warp_shape_k),


### PR DESCRIPTION
## Summary

On H20, the grouped-input-scale mainloop requires additional live accumulator and scale state. With num_ctas_per_sm=3, `__launch_bounds__` limits this 128-thread kernel to about 170 registers per thread, causing the compiler to spill to local memory.

Cap num_ctas_per_sm at 2 for 8-bit grouped-input-scale, non-grouped-masked GEMMs with shape_m >= 6144. The cap is applied after the existing shape and pipeline decisions, so all other config fields remain unchanged.

For the DSV4-Pro w13 shape (m=12288, n=6144, k=7168, E=48):

| metric | CTA3 (before) | CTA2 (after) |
|---|---:|---:|
| benchmark latency | 5.612 ms | 4.247 ms (-24.3%) |
| registers/thread | 168 | 236 |
| local loads/stores | 34.2M / 19.2M | 0 / 0 |
| spilling requests | 53.6M | 0 |

The additional occupancy from CTA3 does not offset the spill cost at large M. Small-M and grouped-masked cases are left unchanged because they still benefit from the extra CTA.
