### PR TITLE
Fix H20 packed-K GEMM correctness

### DIFF
--- a/humming/include/humming/epilogue/gmem_writer.cuh
+++ b/humming/include/humming/epilogue/gmem_writer.cuh
@@ -132,10 +132,12 @@ public:
         tma_store_2d(ctx.smem.reduce + smem_offset, tensor_map_ptr, col_offset2, row_offset);
       } else if (slice_count == 1 || slice_id == 0) {
         tma_store_2d(ctx.smem.reduce + smem_offset, tensor_map_ptr, col_offset2, row_offset);
-        if (slice_count > 1) tma_wait_store_group<0>();
       } else {
         tma_reduce_add_2d(ctx.smem.reduce + smem_offset, tensor_map_ptr, col_offset2, row_offset);
-        if (slice_id != slice_count - 1) tma_wait_store_group<0>();
+      }
+      tma_commit_store_group();
+      if constexpr (kUseStreamK) {
+        if (slice_count > 1 && slice_id != slice_count - 1) tma_wait_store_group<0>();
       }
     }
   }

--- a/humming/include/humming/epilogue/pipeline.cuh
+++ b/humming/include/humming/epilogue/pipeline.cuh
@@ -59,6 +59,9 @@ public:
     PRAGMA_UNROLL
     for (uint32_t i = 0; i < kNumWriteSplits; i++) {
       smem_writer.write(regs_c_ptr, slice_count, i);
+      if constexpr (Ctx::kUseTmaC) {
+        if (ctx.is_math_thread()) tma_fence_async_shared();
+      }
       ctx.sync_math_threads();
       gmem_writer.write(slice_id, slice_count, i);
       ctx.sync_math_threads();

--- a/humming/include/humming/epilogue/smem_reducer.cuh
+++ b/humming/include/humming/epilogue/smem_reducer.cuh
@@ -30,7 +30,8 @@ public:
   CUDA_INLINE
   void reduce(uint32_t *regs_ptr) {
     constexpr uint32_t num_int4s = sizeof(CRegistersArrayType) / 16;
-    constexpr uint32_t num_int4s_per_time = num_int4s / MAX(WarpShape::M / 16, 1);
+    constexpr uint32_t num_reduce_iters = MAX(CEIL_DIV(WarpShape::M, 16), 1);
+    constexpr uint32_t num_int4s_per_time = CEIL_DIV(num_int4s, num_reduce_iters);
     constexpr uint32_t group_num_warps = BlockShape::K / WarpShape::K;
     constexpr uint32_t num_groups = Ctx::kNumMathThreads / 32 / group_num_warps;
     uint32_t group_id = ctx.warp_id() % num_groups;
@@ -45,7 +46,9 @@ public:
 
       PRAGMA_UNROLL
       for (uint32_t i = 0; i < num_int4s_per_time; i++) {
-        smem_arr[buffer_id][group_id][i][laneid] = regs_int4_ptr[i];
+        if (m * num_int4s_per_time + i < num_int4s) {
+          smem_arr[buffer_id][group_id][i][laneid] = regs_int4_ptr[i];
+        }
       };
     };
 
@@ -54,6 +57,7 @@ public:
 
       PRAGMA_UNROLL
       for (uint32_t i = 0; i < num_int4s_per_time; i++) {
+        if (m * num_int4s_per_time + i >= num_int4s) continue;
         int4 val = smem_arr[buffer_id][group_id][i][laneid];
 
         ValTypeC32 *sval_scalar_ptr = reinterpret_cast<ValTypeC32 *>(&val);
@@ -71,7 +75,7 @@ public:
     };
 
     PRAGMA_UNROLL
-    for (uint32_t m = 0; m < MAX(WarpShape::M / 16, 1); m++) {
+    for (uint32_t m = 0; m < num_reduce_iters; m++) {
       PRAGMA_UNROLL
       for (uint32_t i = 1; i < group_num_warps; i *= 2) {
         uint32_t buffer_id = group_warp_id % (group_num_warps / (2 * i));

--- a/humming/include/humming/utils/ptx/tma.cuh
+++ b/humming/include/humming/utils/ptx/tma.cuh
@@ -110,6 +110,10 @@ CUDA_INLINE void tma_commit_store_group() {
   asm volatile("cp.async.bulk.commit_group;\n");
 };
 
+CUDA_INLINE void tma_fence_async_shared() {
+  asm volatile("fence.proxy.async.shared::cta;\n" ::: "memory");
+};
+
 template <uint32_t N, bool only_wait_read = false>
 CUDA_INLINE void tma_wait_store_group() {
   if constexpr (only_wait_read) {

--- a/humming/tune/sm90_h20.py
+++ b/humming/tune/sm90_h20.py
@@ -98,6 +98,8 @@ class Sm90H20Heuristics(DeviceHeuristics):
         block_shape_m, block_shape_n, block_shape_k = config["block_shape"]
         num_ctas_per_sm = config.get("num_ctas_per_sm", 1)
         warp_shape_m, warp_shape_n, warp_shape_k = config["warp_shape"]
+        if meta.use_packed_k_layout:
+            warp_shape_n = max(warp_shape_n, 32)
         num_stages = 3
         assert meta.shape_n % block_shape_n == 0
 


### PR DESCRIPTION
## Summary

This PR fixes three correctness issues in the H20 packed-K GEMM path used by dense W4AFP8/FP8 workloads:

- keep packed-K warp-N large enough for the double-buffered S2R pipeline;
- preserve trailing accumulator vectors when the K-warp reduction partition has a partial tail;
- establish the required shared-memory proxy ordering and TMA store completion before epilogue buffer reuse.

The changes are limited to Humming kernel selection, reduction, and epilogue synchronization. They do not add or modify checkpoint quantization schemas.

## Root cause

### Packed-K warp-N selection

Packed-K maps each warp iteration to a 16-column N fragment. The S2R pipeline alternates between two buffers, so it requires at least two N iterations. The H20 heuristic could select `warp_shape_n=16`, leaving only one iteration and violating that pipeline invariant.

Packed-K configurations now clamp warp-N to 32. Non-packed layouts keep their previous heuristic result.

### Partial accumulator tail in K-warp reduction

The shared-memory K-warp reducer partitioned the flattened accumulator register array using floor division for both the reduction iteration count and the vectors handled per iteration. Whenever the register count was not evenly divisible by `floor(warp_shape_m / 16)`, the trailing vectors were never moved through shared memory and therefore never accumulated across K warps.

Warp-M 56 is the concrete H20 reproducer, not a special-cased shape. With warp-N 32 and FP32 accumulation, the register array contains 14 `int4` vectors per thread. The old calculation used three iterations of four vectors and processed only 12. The two omitted vectors collectively represent the final 8 rows of the 56x128 output tile. Other shapes can exhibit the same truncation whenever their flattened register count leaves a remainder under the old partitioning.

The reducer now uses ceiling division for the iteration count and per-iteration width, with bounds checks for the partial final chunk. This handles the general remainder case without a block-M-specific branch.

### TMA-C shared-memory proxy ordering

The epilogue writes an output tile to shared memory through the generic proxy, then TMA reads the same tile through the async proxy. A thread barrier coordinates the writers but does not make generic-proxy writes visible to the TMA async proxy.

Every math writer now issues `fence.proxy.async.shared::cta` before the existing synchronization. TMA output operations are also committed as store groups, and outstanding stores are waited on where required before the shared-memory source buffer is reused.

Without this ordering, the affected server configuration produced corrupted logits and repetitive output even though the individual kernel configuration could appear correct in isolated runs.

## Validation

- H20 heuristic tests: 20 passed.
- Targeted H20 GPU tests passed for:
  - the representative warp-M 56 partial reduction tail;
  - TMA-C shared-memory buffer reuse;
  - the exact M=160, warp-M 56, TMA, stream-K dense configuration selected on H20.
- Server regression before the proxy fence: 0/9 GSM8K examples correct.
- Short server validation after the fix: 8/9 examples correct.
- 200-example validation after the fix: 0.96 accuracy.
- Full `gsm8k_train8_test1319.jsonl` validation after the fix: 1275/1319 correct, or 0.966641 accuracy. The matching baseline was 1263/1319, or 0.957544.
- Full-run server logs contained no CUDA, assertion, traceback, or runtime errors.

The proxy-ordering failure is timing-sensitive: the focused GPU tests exercise the affected path, but removing only the proxy fence does not currently make them fail deterministically. The server-level accuracy regression is therefore the effective fail-before/pass-after validation for that part of the fix.
