### PR TITLE
fix: restore E8M0 to BF16 dequantization

### DIFF
--- a/humming/include/humming/datatype/dequant_single.cuh
+++ b/humming/include/humming/datatype/dequant_single.cuh
@@ -89,7 +89,7 @@ CUDA_INLINE uint32_t fp_to_fp(uint32_t val) {
   static_assert(SourceType::kExponentBits <= TargetType::kExponentBits);
   static_assert(SourceType::kMantissaBits <= TargetType::kMantissaBits);
   static_assert(SourceType::kBits < TargetType::kBits);
-  static_assert(SourceType::kIsSigned && TargetType::kIsSigned);
+  static_assert(!SourceType::kIsSigned || TargetType::kIsSigned);
   static_assert(TargetType::kBits == 16 || TargetType::kBits == 8 || TargetType::kBits == 4);
 
   constexpr uint32_t repeated_one = TargetType::kBits == 16 ? 0x00010001 : (TargetType::kBits == 8 ? 0x01010101 : 0x11111111);

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -1,3 +1,5 @@
+import itertools
+
 import pytest
 import torch
 
@@ -16,25 +18,45 @@ from humming.utils.weight import (
 )
 
 
-@pytest.mark.parametrize("a_dtype", ["float16", "bfloat16", "float8e4m3", "int8", "int4"])
 @pytest.mark.parametrize(
-    "b_dtype",
+    (
+        "a_dtype",
+        "b_dtype",
+        "c_dtype",
+        "bs_dtype",
+        "input_scale_group_size",
+        "weight_scale_group_size",
+    ),
     [
-        "uint3",
-        "uint4",
-        "uint5",
-        "uint8",
-        "int4",
-        "int8",
-        "float3e2m0",
-        "float4e1m2",
-        "float8e1m6",
+        *itertools.product(
+            ["float16", "bfloat16", "float8e4m3", "int8", "int4"],
+            [
+                "uint3",
+                "uint4",
+                "uint5",
+                "uint8",
+                "int4",
+                "int8",
+                "float3e2m0",
+                "float4e1m2",
+                "float8e1m6",
+            ],
+            ["float16", "bfloat16"],
+            ["float16", "bfloat16", "float8e5m2", "float8e4m3"],
+            [16, 32, 64, 128, 0],
+            [16, 32, 64, 128, 0],
+        ),
+        pytest.param(
+            "bfloat16",
+            "float4e2m1",
+            "bfloat16",
+            "float8e8m0",
+            0,
+            32,
+            id="e8m0-to-bfloat16-group-scale",
+        ),
     ],
 )
-@pytest.mark.parametrize("c_dtype", ["float16", "bfloat16"])
-@pytest.mark.parametrize("bs_dtype", ["float16", "bfloat16", "float8e5m2", "float8e4m3"])
-@pytest.mark.parametrize("input_scale_group_size", [16, 32, 64, 128, 0])
-@pytest.mark.parametrize("weight_scale_group_size", [16, 32, 64, 128, 0])
 @pytest.mark.parametrize("mma_type", ["mma", "wgmma"])
 def test_scale(
     a_dtype,


### PR DESCRIPTION
## Summary

Restore the pre-`32ca4bc` floating-point widening constraint so the existing E8M0-to-BF16 conversion remains reachable.

`32ca4bc` required both source and target formats to be signed before the dedicated E8M0 conversion branch, causing W4A16 kernels with E8M0 group scales to fail during compilation. This change restores the previous constraint and adds MMA/WGMMA regression coverage.

## Validation

- `ruff check tests/test_scale.py`
- `python3 -m py_compile tests/test_scale.py`
- GPU test not run locally