### PR TITLE
Disable warp specialization for SM120 indexed GEMM

### DIFF
--- a/humming/tune/sm120.py
+++ b/humming/tune/sm120.py
@@ -79,13 +79,13 @@ class Sm120Heuristics(Sm89Heuristics):
         elif is_wna16:
             config["use_tma"] = True
             config["use_warp_spec"] = True
-            config["num_stages"] = cls._fit_num_stages(
-                meta, config, gemm_type, reduce_overlap=False
-            )
+            config["num_stages"] = cls._fit_num_stages(meta, config, gemm_type, reduce_overlap=False)
 
         if gemm_type == GemmType.INDEXED:
+            # Indexed addressing is incompatible with the warp-specialized pipeline.
             config["use_tma_a"] = False
             config["use_tma_c"] = False
+            config["use_warp_spec"] = False
 
         group_size = meta.input_scale_group_size or meta.weight_scale_group_size
         if cls._is_mxmma(meta.a_dtype, group_size, meta.use_fused_e8m0_scale):


### PR DESCRIPTION
Fixes #50.

## Problem

Commit `8a7888f` correctly disables TMA for indexed-GEMM A/C operands, allowing WNA16 kernels to compile on NVIDIA GB10 / SM121. However, the SM120 heuristic still enables the warp-specialized producer/consumer pipeline. On GB10, those compiled indexed kernels return silently incorrect output (and, for one small-M channel-scale case, NaNs).

This is more dangerous than the previous compilation failure because engine startup can now succeed while inference results are corrupted.

## Change

Disable `use_warp_spec` for SM120/SM121 indexed GEMM. TMA remains enabled globally and is still used for supported operands; only A/C TMA and the incompatible warp-specialized pipeline are disabled.

## GB10 validation

Environment: NVIDIA GB10, compute capability 12.1, driver 580.126.09, CUDA 13.0, NVRTC compiler.

For `M=128, N=2048, K=1024, E=4, top_k=2`, the auto-selected WNA16 config is `(48, 256, 64)`. Results are compared with a PyTorch dequantized reference:

| activation/output | weight group | current main rel RMSE / cosine | this PR rel RMSE / cosine |
|---|---:|---:|---:|
| FP16 | channel | 1.00497 / -0.00129 | 0.000354 / 0.9999999 |
| FP16 | 128 | 1.00216 / 0.00060 | 0.000288 / 1.0000000 |
| BF16 | channel | 1.00495 / -0.00130 | 0.002835 / 0.9999959 |
| BF16 | 128 | 1.00215 / 0.00061 | 0.002296 / 0.9999973 |

The `(16, 256, 64)` small-M path was also checked with `M=1, N=8192, K=1024`: current main produces NaNs for channel scale and rel RMSE 1.2096 for group-128; both paths recover to cosine >= 0.999996 with this change.

The original forced pre-fix settings were separately verified to reproduce both NVRTC static assertions from #50, confirming that this exercises the reported path.

## Checks

- `uvx ruff check humming/tune/sm120.py`
- `uvx ruff format --check humming/tune/sm120.py`
- GB10 compilation and numerical checks above for FP16/BF16, channel/group-128 scales, and block-M 16/48

Implementation, reproduction scripting, and validation were performed with Codex assistance; I inspected the changed path and all reported numerical outputs.